### PR TITLE
feat: text length validation and trimming in popup (ticket 3.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,7 @@ Response: { "summary": "...", "wordCount": 850, "processingTimeMs": 4200 }
 - **`@testing-library/react` added for Popup component tests** — Plain jsdom is enough for pure functions (`extract.ts`), but React components need `@testing-library/react` to render and interact. Added `@testing-library/jest-dom` for DOM matchers (`toBeInTheDocument`). Setup in `src/setupTests.ts`; Vitest configured with `globals: true` and `setupFiles: ['./src/setupTests.ts']` in `vitest.config.ts`.
 - **`vi.useFakeTimers()` breaks `waitFor` from Testing Library** — `waitFor` internally uses `setInterval`, which becomes fake when `vi.useFakeTimers()` is active. This causes the timeout test to hang. Solution: mock `fetch` to immediately reject with `new DOMException('Aborted', 'AbortError')` instead of simulating the real 60s wait. This tests the catch block logic correctly without timer complexity.
 - **`gh pr create --head` flag needed with untracked files** — `gh pr create` aborts if the working tree has untracked files, even if they are irrelevant to the PR. Use `--head feature/branch-name` to bypass this check.
+- **Text length validation in popup (ticket 3.5)** — `Popup.tsx` splits `extracted.text` on `\s+` and filters empty strings to get a word array. If fewer than 100 words, sets `too-short` status and returns early (no backend call). If 10,000 or more words, slices to 10,000 and joins back with spaces before sending. The same `words` array is reused for both the length check and the trim, avoiding a second split.
 
 ---
 

--- a/extension/src/popup/Popup.test.tsx
+++ b/extension/src/popup/Popup.test.tsx
@@ -14,7 +14,8 @@ vi.stubGlobal('chrome', {
   },
 })
 
-const EXTRACTED = { title: 'Test Article', text: 'Some article text.' }
+const LONG_TEXT = Array(120).fill('word').join(' ')
+const EXTRACTED = { title: 'Test Article', text: LONG_TEXT }
 const SUMMARY_RESPONSE = { summary: 'Kratki rezime.', wordCount: 4, processingTimeMs: 100 }
 
 beforeEach(() => {

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import styles from './Popup.module.css'
 import './popup.css'
 
-type Status = 'idle' | 'loading' | 'success' | 'error' | 'not-article' | 'unsupported-page' | 'timeout'
+type Status = 'idle' | 'loading' | 'success' | 'error' | 'not-article' | 'unsupported-page' | 'timeout' | 'too-short'
 
 const BACKEND_URL = 'http://localhost:5000/api/summary'
 const FETCH_TIMEOUT_MS = 60_000
@@ -32,10 +32,18 @@ export default function Popup() {
         return
       }
 
+      const words = extracted.text.split(/\s+/).filter(Boolean)
+      if (words.length < 100) {
+        setStatus('too-short')
+        return
+      }
+
+      const trimmedText = words.slice(0, 10_000).join(' ')
+
       const response = await fetch(BACKEND_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: tab.url, text: extracted.text }),
+        body: JSON.stringify({ url: tab.url, text: trimmedText }),
         signal: controller.signal,
       })
 
@@ -111,6 +119,12 @@ export default function Popup() {
       {status === 'timeout' && (
         <p className={`${styles.statusMessage} ${styles.statusError}`}>
           Zahtev je trajao predugo. Pokušaj ponovo.
+        </p>
+      )}
+
+      {status === 'too-short' && (
+        <p style={{ marginTop: 12, color: '#888', fontSize: 13 }}>
+          Članak je prekratak za sumarizaciju.
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Adds `too-short` status to `Status` type in `Popup.tsx`
- Shows "Članak je prekratak za sumarizaciju." if extracted article text has fewer than 100 words
- Trims text to 10,000 words before sending to backend (no backend call for short articles)
- Fixes existing `Popup.test.tsx` mocks to use 100+ word text (needed after validation was added)

## Test plan
- [ ] All 12 existing Vitest tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual test: open a short page → "Članak je prekratak za sumarizaciju." appears
- [ ] Manual test: open a real news article → summary generated normally

References #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)