### PR TITLE
feat: SSE streaming + Gemini API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local config with secrets — never commit
+appsettings.Development.json
+
 # .NET
 bin/
 obj/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,9 @@ Primary purpose is educational — user is learning AI development while buildin
 | Text extraction | Readability.js |
 | Backend | ASP.NET Core .NET 10 |
 | AI SDK | Semantic Kernel 1.24.1 |
-| Model runner | Ollama (Docker) |
-| Model | Llama 3.1 8B |
+| Model provider | Google Gemini API (gemini-2.5-flash) |
+| Model runner | Ollama (Docker) — kept for local fallback |
+| Local model | Llama 3.1 8B |
 | Infrastructure | Docker Compose |
 
 ---
@@ -87,9 +88,8 @@ ExtensionSummarizer/
 
 ### Active development (during a feature/task)
 - Backend is developed and run locally in **Visual Studio** (F5, hot reload, debugger)
-- Only the Ollama container runs in Docker during development: `docker compose up ollama -d`
-- `appsettings.json` points to `http://localhost:11434` — correct for local dev
-- Docker Compose overrides this with `Ollama__BaseUrl=http://ollama:11434` for the container env
+- Gemini API key lives in `appsettings.Development.json` (gitignored) — never in `appsettings.json`
+- Ollama container still runs in Docker for local fallback: `docker compose up ollama -d`
 
 ### End of feature/task
 - After development is done and committed, rebuild **only the API container**:
@@ -124,7 +124,8 @@ Response: { "summary": "...", "wordCount": 850, "processingTimeMs": 4200 }
 - System + user prompts: English
 - Output: Serbian (Latin script)
 - Temperature: 0.3, MaxTokens: 300
-- Ollama is called via its OpenAI-compatible `/v1` endpoint (works with standard SK OpenAI connector)
+- Gemini is called via its OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai/`) — works with standard SK `AddOpenAIChatCompletion` connector, no extra NuGet needed
+- Streaming uses raw HttpClient against the same endpoint with `Authorization: Bearer {apiKey}` header
 
 ### Prompt tuning decisions (ticket 1.2 — validated via direct Ollama API calls)
 
@@ -189,6 +190,13 @@ Response: { "summary": "...", "wordCount": 850, "processingTimeMs": 4200 }
 - **CSS module consistency** — All status message blocks in `Popup.tsx` use `${styles.statusMessage} ${styles.statusError}` or `${styles.statusMuted}`. No inline styles remain in the component. `Popup.module.css` is the single source of truth for all popup styles; `popup.css` contains only the spinner `@keyframes` animation.
 - **PR conflict resolution pattern (Sprint 3)** — PRs #31 and #32 were branched before PR #29 (AbortController timeout) was merged, causing conflicts. Resolution order: merge oldest-base PRs first (CSS layout → spinner → logic changes → refactoring). Each rebase was done with `git rebase origin/main`; conflicts resolved manually, then `git push --force-with-lease`. Fix PR base branch with `gh pr edit <number> --base main`.
 - **Worktree branch lock** — A branch checked out in a worktree cannot be checked out in the main repo. Use `cd` to the worktree dir and run git commands there. `gh pr merge --delete-branch` will also fail for worktree branches — omit `--delete-branch` in that case.
+- **Streaming implemented on `feature/4.2-streaming`** — SSE endpoint at `POST /api/summary/stream`. Backend uses raw HttpClient with `HttpCompletionOption.ResponseHeadersRead` and `Response.BodyWriter.FlushAsync()` (not `Response.Body.FlushAsync()` — different flush semantics). Extension routes streaming through the background service worker because Chrome popup pages buffer cross-origin ReadableStream until complete. Popup↔worker communication via `chrome.runtime.connect` port.
+- **Chrome MV3 service worker keepalive** — Service workers are killed after ~30s of inactivity. Popup sends a `{ type: 'ping' }` message every 20s to keep the worker alive during Ollama/Gemini cold start. Worker ignores ping messages.
+- **Gemini API key storage** — Key goes in `appsettings.Development.json` which is gitignored. Never in `appsettings.json`. Added `appsettings.Development.json` to `.gitignore`.
+- **Gemini model availability** — `gemini-2.0-flash` had `limit: 0` quota on this project's free tier despite being listed. `gemini-2.5-flash` works. Always verify with `GET /v1beta/openai/models` and a test curl before committing to a model name.
+- **Gemini OpenAI-compat model ID format** — Use short form (`gemini-2.5-flash`), not the full form (`models/gemini-2.5-flash`) returned by the models list endpoint.
+- **AMD GPU in Docker Desktop on Windows** — Not feasible for Ollama compute. Mesa RADV needs `/dev/dri` (unavailable in Docker Desktop WSL2). AMD's WSL Vulkan driver (`amdvlk64.dll`) is a Windows DLL, unusable in Linux containers. Only solution is running Ollama natively on Windows.
+- **Ollama warm-up on backend startup** — `Program.cs` registers `app.Lifetime.ApplicationStarted` callback that sends a fire-and-forget dummy request to load the model into memory. Prevents cold-start latency (~30-40s) on first real request. Error is silently swallowed — warm-up is best-effort.
 
 ---
 

--- a/backend/ExtensionSummarizer.API/Controllers/SummaryController.cs
+++ b/backend/ExtensionSummarizer.API/Controllers/SummaryController.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.Features;
 using ExtensionSummarizer.API.Models;
 using ExtensionSummarizer.API.Services;
+using System.Text.Json;
+using System.Diagnostics;
 
 namespace ExtensionSummarizer.API.Controllers;
 
@@ -16,5 +19,50 @@ public class SummaryController(ISummaryService summaryService) : ControllerBase
 
         var result = await summaryService.SummarizeAsync(request);
         return Ok(result);
+    }
+
+    [HttpPost("stream")]
+    public async Task SummarizeStream([FromBody] SummaryRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Text))
+        {
+            Response.StatusCode = 400;
+            return;
+        }
+
+        Response.ContentType = "text/event-stream";
+        Response.Headers["Cache-Control"] = "no-cache";
+        Response.Headers["X-Accel-Buffering"] = "no";
+
+        // Kestrel buffers the response body by default — disable it so each
+        // FlushAsync actually sends data to the client immediately.
+        HttpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
+        var wordCount = request.Text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            // Send an SSE comment first. This flushes the response headers to the
+            // client immediately, so the browser knows the connection is open.
+            await Response.WriteAsync(": connected\n\n", cancellationToken);
+            await Response.BodyWriter.FlushAsync(cancellationToken);
+
+            await foreach (var token in summaryService.SummarizeStreamAsync(request, cancellationToken))
+            {
+                var tokenEvent = JsonSerializer.Serialize(new { type = "token", content = token });
+                await Response.WriteAsync($"data: {tokenEvent}\n\n", cancellationToken);
+                await Response.BodyWriter.FlushAsync(cancellationToken);
+            }
+
+            stopwatch.Stop();
+            var doneEvent = JsonSerializer.Serialize(new { type = "done", wordCount, processingTimeMs = (int)stopwatch.ElapsedMilliseconds });
+            await Response.WriteAsync($"data: {doneEvent}\n\n", cancellationToken);
+            await Response.BodyWriter.FlushAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected before the stream completed — expected, not an error.
+        }
     }
 }

--- a/backend/ExtensionSummarizer.API/Program.cs
+++ b/backend/ExtensionSummarizer.API/Program.cs
@@ -1,11 +1,14 @@
 using ExtensionSummarizer.API.Services;
 using Scalar.AspNetCore;
+using System.Text;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 builder.Services.AddOpenApi();
 
+builder.Services.AddHttpClient();
 builder.Services.AddScoped<ISummaryService, SummaryService>();
 
 builder.Services.AddCors(options =>
@@ -27,5 +30,30 @@ if (app.Environment.IsDevelopment())
 app.UseCors();
 app.UseAuthorization();
 app.MapControllers();
+
+// Fire-and-forget warm-up: loads the model into Ollama's memory at startup
+// so the first real request does not pay the cold-start penalty (~30s).
+app.Lifetime.ApplicationStarted.Register(() =>
+{
+    _ = Task.Run(async () =>
+    {
+        try
+        {
+            var ollamaUrl = app.Configuration["Ollama:BaseUrl"] ?? "http://localhost:11434";
+            var model = app.Configuration["Ollama:Model"] ?? "llama3.1";
+            var body = JsonSerializer.Serialize(new
+            {
+                model,
+                messages = new[] { new { role = "user", content = "hi" } },
+                max_tokens = 1
+            });
+            using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(3) };
+            await client.PostAsync(
+                $"{ollamaUrl}/v1/chat/completions",
+                new StringContent(body, Encoding.UTF8, "application/json"));
+        }
+        catch { /* warm-up is best-effort — never block startup */ }
+    });
+});
 
 app.Run();

--- a/backend/ExtensionSummarizer.API/Services/ISummaryService.cs
+++ b/backend/ExtensionSummarizer.API/Services/ISummaryService.cs
@@ -5,4 +5,5 @@ namespace ExtensionSummarizer.API.Services;
 public interface ISummaryService
 {
     Task<SummaryResponse> SummarizeAsync(SummaryRequest request);
+    IAsyncEnumerable<string> SummarizeStreamAsync(SummaryRequest request, CancellationToken cancellationToken = default);
 }

--- a/backend/ExtensionSummarizer.API/Services/SummaryService.cs
+++ b/backend/ExtensionSummarizer.API/Services/SummaryService.cs
@@ -3,6 +3,9 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using ExtensionSummarizer.API.Models;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
 
 namespace ExtensionSummarizer.API.Services;
 
@@ -35,15 +38,15 @@ public class SummaryService(IConfiguration configuration) : ISummaryService
 
     public async Task<SummaryResponse> SummarizeAsync(SummaryRequest request)
     {
-        var ollamaUrl = configuration["Ollama:BaseUrl"] ?? "http://localhost:11434";
-        var model = configuration["Ollama:Model"] ?? "llama3.1";
+        var apiKey = configuration["Gemini:ApiKey"] ?? throw new InvalidOperationException("Gemini:ApiKey is not configured.");
+        var model = configuration["Gemini:Model"] ?? "gemini-2.0-flash";
 
-        // Ollama exposes an OpenAI-compatible API at /v1
+        // Gemini exposes an OpenAI-compatible API at this endpoint
         var kernel = Kernel.CreateBuilder()
             .AddOpenAIChatCompletion(
                 modelId: model,
-                apiKey: "ollama",
-                endpoint: new Uri($"{ollamaUrl}/v1"))
+                apiKey: apiKey,
+                endpoint: new Uri("https://generativelanguage.googleapis.com/v1beta/openai/"))
             .Build();
 
         var chatService = kernel.GetRequiredService<IChatCompletionService>();
@@ -70,5 +73,77 @@ public class SummaryService(IConfiguration configuration) : ISummaryService
             WordCount = request.Text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length,
             ProcessingTimeMs = (int)stopwatch.ElapsedMilliseconds
         };
+    }
+
+    public async IAsyncEnumerable<string> SummarizeStreamAsync(
+        SummaryRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var apiKey = configuration["Gemini:ApiKey"] ?? throw new InvalidOperationException("Gemini:ApiKey is not configured.");
+        var model = configuration["Gemini:Model"] ?? "gemini-2.0-flash";
+
+        var messages = new object[]
+        {
+            new { role = "system",    content = SystemPrompt },
+            new { role = "user",      content = FewShotExampleInput },
+            new { role = "assistant", content = FewShotExampleOutput },
+            new { role = "user",      content = $"Summarize this news article:\n\n{request.Text}" }
+        };
+
+        var body = JsonSerializer.Serialize(new
+        {
+            model,
+            messages,
+            stream = true,
+            temperature = 0.3,
+            max_tokens = 300
+        });
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
+        using var httpRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        httpRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+
+        // ResponseHeadersRead returns as soon as the first header byte arrives,
+        // allowing us to read the response body as a stream token by token.
+        using var response = await client.SendAsync(
+            httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(stream);
+
+        // ReadLineAsync returns null when the stream is closed — the async-safe
+        // alternative to checking EndOfStream, which would block the thread.
+        string? line;
+        while ((line = await reader.ReadLineAsync(cancellationToken)) != null)
+        {
+            if (string.IsNullOrWhiteSpace(line) || !line.StartsWith("data: ")) continue;
+
+            var data = line["data: ".Length..];
+            if (data == "[DONE]") yield break;
+
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(data); }
+            catch { continue; }
+
+            using (doc)
+            {
+                if (doc.RootElement.TryGetProperty("choices", out var choices) &&
+                    choices.GetArrayLength() > 0 &&
+                    choices[0].TryGetProperty("delta", out var delta) &&
+                    delta.TryGetProperty("content", out var content))
+                {
+                    var text = content.GetString();
+                    if (!string.IsNullOrEmpty(text))
+                        yield return text;
+                }
+            }
+        }
     }
 }

--- a/extension/src/background/background.ts
+++ b/extension/src/background/background.ts
@@ -1,7 +1,73 @@
-// Background service worker — handles extension lifecycle
+// Background service worker — handles extension lifecycle and SSE streaming.
+//
+// Streaming goes through the service worker because Chrome extension popup
+// pages buffer cross-origin ReadableStream responses until the full response
+// completes. Service workers do not have this limitation.
+//
+// The popup opens a port named 'summary-stream', sends the request payload,
+// and receives token/done/error events back via port.postMessage.
+
+const BACKEND_URL = 'http://localhost:5000/api/summary/stream'
 
 chrome.runtime.onInstalled.addListener(() => {
   console.log('ExtensionSummarizer installed')
+})
+
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name !== 'summary-stream') return
+
+  const abortController = new AbortController()
+
+  // When the popup closes or disconnects the port, abort the fetch so Ollama
+  // does not keep generating tokens in the background.
+  port.onDisconnect.addListener(() => {
+    abortController.abort()
+  })
+
+  port.onMessage.addListener(async (request: { type?: string; url: string; text: string }) => {
+    if (request.type === 'ping') return
+    try {
+      const response = await fetch(BACKEND_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal: abortController.signal,
+      })
+
+      if (!response.ok || !response.body) {
+        port.postMessage({ type: 'error' })
+        return
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+
+        const lines = buffer.split('\n\n')
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          try {
+            const event = JSON.parse(line.slice(6))
+            port.postMessage(event)
+          } catch { /* ignore malformed SSE lines */ }
+        }
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        // Port was disconnected (popup closed or timeout) — nothing to do.
+        return
+      }
+      port.postMessage({ type: 'error' })
+    }
+  })
 })
 
 export {}

--- a/extension/src/popup/Popup.module.css
+++ b/extension/src/popup/Popup.module.css
@@ -72,3 +72,15 @@
 .statusError {
   color: #dc2626;
 }
+
+.streaming::after {
+  content: '▋';
+  margin-left: 2px;
+  color: #9ca3af;
+  animation: blink 0.7s steps(1) infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}

--- a/extension/src/popup/Popup.test.tsx
+++ b/extension/src/popup/Popup.test.tsx
@@ -6,22 +6,77 @@ import Popup from './Popup'
 // Mock Chrome APIs
 const mockSendMessage = vi.fn()
 const mockTabsQuery = vi.fn()
+const mockConnect = vi.fn()
 
 vi.stubGlobal('chrome', {
   tabs: {
     query: mockTabsQuery,
     sendMessage: mockSendMessage,
   },
+  runtime: {
+    connect: mockConnect,
+  },
 })
 
 const LONG_TEXT = Array(120).fill('word').join(' ')
 const EXTRACTED = { title: 'Test Article', text: LONG_TEXT }
-const SUMMARY_RESPONSE = { summary: 'Kratki rezime.', wordCount: 4, processingTimeMs: 100 }
+
+// ─── port mock helpers ────────────────────────────────────────────────────────
+
+// Creates a mock chrome.runtime port. The behavior callback receives two
+// trigger functions: one to fire onMessage listeners, one to fire onDisconnect.
+// The triggers are called after postMessage — i.e. when the popup sends the request.
+function makeMockPort(behavior: (
+  triggerMessage: (event: object) => void,
+  triggerDisconnect: () => void,
+) => void) {
+  const messageListeners: ((event: object) => void)[] = []
+  const disconnectListeners: (() => void)[] = []
+
+  const triggerMessage = (event: object) => messageListeners.forEach((fn) => fn(event))
+  const triggerDisconnect = () => disconnectListeners.forEach((fn) => fn())
+
+  const port = {
+    onMessage: { addListener: (fn: (event: object) => void) => messageListeners.push(fn) },
+    onDisconnect: { addListener: (fn: () => void) => disconnectListeners.push(fn) },
+    postMessage: vi.fn(() => behavior(triggerMessage, triggerDisconnect)),
+    disconnect: vi.fn(triggerDisconnect),
+  }
+
+  mockConnect.mockReturnValue(port)
+  return port
+}
+
+// Simulates a successful stream: one token then done.
+function mockPortSuccess(summary: string, wordCount: number, processingTimeMs: number) {
+  makeMockPort((triggerMessage) => {
+    setTimeout(() => {
+      triggerMessage({ type: 'token', content: summary })
+      triggerMessage({ type: 'done', wordCount, processingTimeMs })
+    }, 0)
+  })
+}
+
+// Simulates a non-OK backend response.
+function mockPortError() {
+  makeMockPort((triggerMessage) => {
+    setTimeout(() => triggerMessage({ type: 'error' }), 0)
+  })
+}
+
+// Simulates a timeout: port disconnects immediately (as if the 60s timer fired).
+function mockPortTimeout() {
+  makeMockPort((_triggerMessage, triggerDisconnect) => {
+    setTimeout(() => triggerDisconnect(), 0)
+  })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
   mockTabsQuery.mockResolvedValue([{ id: 1, url: 'https://example.com' }])
   mockSendMessage.mockResolvedValue(EXTRACTED)
-  vi.restoreAllMocks()
+  mockConnect.mockReset()
 })
 
 afterEach(() => {
@@ -29,8 +84,8 @@ afterEach(() => {
 })
 
 describe('Popup', () => {
-  it('shows timeout message when fetch is aborted', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError')))
+  it('shows timeout message when request times out', async () => {
+    mockPortTimeout()
     mockTabsQuery.mockResolvedValue([{ id: 1, url: 'https://example.com' }])
     mockSendMessage.mockResolvedValue(EXTRACTED)
 
@@ -43,7 +98,7 @@ describe('Popup', () => {
   })
 
   it('shows error message when backend returns non-OK response', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+    mockPortError()
     mockTabsQuery.mockResolvedValue([{ id: 1, url: 'https://example.com' }])
     mockSendMessage.mockResolvedValue(EXTRACTED)
 
@@ -67,11 +122,8 @@ describe('Popup', () => {
     })
   })
 
-  it('shows summary on successful response', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(SUMMARY_RESPONSE),
-    }))
+  it('shows summary on successful streaming response', async () => {
+    mockPortSuccess('Kratki rezime.', 120, 1500)
     mockTabsQuery.mockResolvedValue([{ id: 1, url: 'https://example.com' }])
     mockSendMessage.mockResolvedValue(EXTRACTED)
 
@@ -81,6 +133,7 @@ describe('Popup', () => {
     await waitFor(() => {
       expect(screen.getByText('Kratki rezime.')).toBeInTheDocument()
     })
+    expect(screen.getByText(/120 words/)).toBeInTheDocument()
   })
 
   it('shows not-article message when content script returns null', async () => {

--- a/extension/src/popup/Popup.tsx
+++ b/extension/src/popup/Popup.tsx
@@ -3,10 +3,9 @@ import styles from './Popup.module.css'
 import './popup.css'
 import { classifyError } from './popupUtils'
 
-type Status = 'idle' | 'loading' | 'success' | 'error' | 'not-article' | 'unsupported-page' | 'timeout' | 'too-short'
+type Status = 'idle' | 'loading' | 'streaming' | 'success' | 'error' | 'not-article' | 'unsupported-page' | 'timeout' | 'too-short'
 
-const BACKEND_URL = 'http://localhost:5000/api/summary'
-const FETCH_TIMEOUT_MS = 60_000
+const STREAM_TIMEOUT_MS = 180_000
 
 export default function Popup() {
   const [summary, setSummary] = useState<string>('')
@@ -19,9 +18,6 @@ export default function Popup() {
     setStatus('loading')
     setSummary('')
     setTitle('')
-
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
 
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
@@ -40,28 +36,65 @@ export default function Popup() {
       }
 
       const trimmedText = words.slice(0, 10_000).join(' ')
-
-      const response = await fetch(BACKEND_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: tab.url, text: trimmedText }),
-        signal: controller.signal,
-      })
-
-      if (!response.ok) throw new Error('Backend error')
-
-      const data = await response.json()
-      setSummary(data.summary)
       setTitle(extracted.title)
-      setWordCount(data.wordCount)
-      setProcessingTime(data.processingTimeMs)
-      setStatus('success')
+
+      // Streaming goes through the background service worker. Chrome extension
+      // popup pages buffer cross-origin ReadableStream responses until the full
+      // response completes — the service worker does not have this limitation.
+      const port = chrome.runtime.connect({ name: 'summary-stream' })
+      const timeoutId = setTimeout(() => port.disconnect(), STREAM_TIMEOUT_MS)
+      // Chrome MV3 terminates service workers after ~30s of inactivity.
+      // Sending a periodic ping keeps the worker alive during Ollama's cold start.
+      const keepAliveId = setInterval(() => port.postMessage({ type: 'ping' }), 20_000)
+      let firstToken = true
+      let done = false
+
+      await new Promise<void>((resolve, reject) => {
+        port.onMessage.addListener((event) => {
+          if (event.type === 'token') {
+            if (firstToken) {
+              setStatus('streaming')
+              firstToken = false
+            }
+            setSummary((prev) => prev + event.content)
+          } else if (event.type === 'done') {
+            done = true
+            setWordCount(event.wordCount)
+            setProcessingTime(event.processingTimeMs)
+            setStatus('success')
+            clearTimeout(timeoutId)
+            clearInterval(keepAliveId)
+            port.disconnect()
+            resolve()
+          } else if (event.type === 'error') {
+            done = true
+            clearTimeout(timeoutId)
+            clearInterval(keepAliveId)
+            port.disconnect()
+            reject(new Error('Backend error'))
+          }
+        })
+
+        // onDisconnect fires when:
+        //   - the timeout above calls port.disconnect()  → treat as timeout
+        //   - done/error already disconnected the port   → done=true, skip
+        //   - the popup is closed mid-stream             → no-op (context destroyed)
+        port.onDisconnect.addListener(() => {
+          if (!done) {
+            clearTimeout(timeoutId)
+            clearInterval(keepAliveId)
+            reject(new DOMException('Aborted', 'AbortError'))
+          }
+        })
+
+        port.postMessage({ url: tab.url, text: trimmedText })
+      })
     } catch (err) {
       setStatus(classifyError(err))
-    } finally {
-      clearTimeout(timeoutId)
     }
   }
+
+  const isActive = status === 'loading' || status === 'streaming'
 
   return (
     <div className={styles.container}>
@@ -69,10 +102,10 @@ export default function Popup() {
 
       <button
         onClick={handleSummarize}
-        disabled={status === 'loading'}
+        disabled={isActive}
         className={styles.button}
       >
-        {status === 'loading' ? (
+        {isActive ? (
           <span className="btnLoading">
             <span className="spinner" />
             Summarizing
@@ -80,13 +113,17 @@ export default function Popup() {
         ) : 'Summarize'}
       </button>
 
-      {status === 'success' && (
+      {(status === 'streaming' || status === 'success') && (
         <div className={styles.result}>
           {title && <p className={styles.articleTitle}>{title}</p>}
-          <p className={styles.summary}>{summary}</p>
-          <small className={styles.meta}>
-            {wordCount} words · {processingTime}ms
-          </small>
+          <p className={`${styles.summary} ${status === 'streaming' ? styles.streaming : ''}`}>
+            {summary}
+          </p>
+          {status === 'success' && (
+            <small className={styles.meta}>
+              {wordCount} words · {processingTime}ms
+            </small>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Add `POST /api/summary/stream` SSE endpoint — streams tokens one by one to the client as Gemini generates them
- Switch AI provider from Ollama (local) to Google Gemini 2.5 Flash via OpenAI-compatible endpoint
- Route extension streaming through the background service worker (Chrome popup pages buffer cross-origin `ReadableStream` until complete — service workers do not)
- Add 20s keepalive ping from popup to prevent Chrome MV3 service worker termination during long inference calls
- Add Ollama warm-up request on backend startup to eliminate cold-start latency
- Add streaming CSS cursor animation and `streaming` UI status in popup
- Add `appsettings.Development.json` to `.gitignore` to protect API keys

## Test plan

- [ ] Backend: `POST /api/summary/stream` returns `text/event-stream` with `data:` token lines followed by `data: {"type":"done",...}`
- [ ] Extension: popup shows tokens appearing one by one during streaming
- [ ] Extension: keepalive prevents timeout on cold Gemini start
- [ ] `appsettings.Development.json` is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)